### PR TITLE
README.md: "Recordings" section, reformat to 75 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,38 @@
+<!-- -*- fill-column: 75; -*- -->
+
 # Haskell training: 101 and 102.
 
-This repository contains the source for the slides and the exercises used in the
-Haskell trainings at Google. Haskell is not one of the internally "blessed"
-languages, but a dedicated team of volunteers is making use of 20% time to try
-to make Haskell at Google possible! This set of lessons was created in 2016, to
-allow newcomers to the language to get involved with the team.
+This repository contains the source for the slides and the exercises used
+in the Haskell trainings at Google. Haskell is not one of the internally
+"blessed" languages, but a dedicated team of volunteers is making use of
+20% time to try to make Haskell at Google possible! This set of lessons was
+created in 2016, to allow newcomers to the language to get involved with
+the team.
 
 ### Slides
 
-The slides use LaTeX. You'll need `xelatex` installed to build them. Simply run
-`make` to create the PDFs. You must also have the [Yanone Kaffeesatz](https://yanone.de/fonts/kaffeesatz/)
-fonts installed on your machine. 
+The slides use LaTeX. You'll need `xelatex` installed to build them. Simply
+run `make` to create the PDFs. You must also have the [Yanone
+Kaffeesatz](https://yanone.de/fonts/kaffeesatz/) fonts installed on your
+machine.
 
 ### Exercises
 
 The codelabs only require ghc to be installed and in the path. Please read
 Codelab.hs and follow the instructions!
 
+### Recordings
+
+Public recordings of the training are available: [Haskell
+101](http://youtu.be/cTN1Qar4HSw), [Haskell
+102](http://youtu.be/Ug9yJnOYR4U).
+
 ### Release
 
-See the [releases](https://github.com/google/haskell-trainings/releases) to 
+See the [releases](https://github.com/google/haskell-trainings/releases) to
 download the generated PDFs and the codelabs.
 
 # Warning
 
-This code is presented as-is, without the speaker notes. Public recordings of
-the training are available: [Haskell 101](http://youtu.be/cTN1Qar4HSw),
-[Haskell 102](http://youtu.be/Ug9yJnOYR4U). This is not an officially supported
-Google product.
+This code is presented as-is, without the speaker notes. This is not an
+officially supported Google product.


### PR DESCRIPTION
It does not make sense to have links to the recordings in the "Warning"
section.  It is also better to specify the formatting width explicitly.

Reformatted to 75 characters.

Closes #6