### PR TITLE
Make the Makefiles also work under /bin/sh.

### DIFF
--- a/haskell_101/codelab/00_setup/Makefile
+++ b/haskell_101/codelab/00_setup/Makefile
@@ -35,11 +35,11 @@ clean:
 #
 
 $(TOOL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(TOOL) ]] || ([[ -e `which cabal` ]] && echo cabal > $(TOOL)) || true)
-	@([[ -s $(TOOL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
 
 $(REPL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(REPL) ]] || ([[ -e `which cabal` ]] && echo cabal repl > $(REPL)) || true)
-	@([[ -s $(REPL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_101/codelab/01_functions/Makefile
+++ b/haskell_101/codelab/01_functions/Makefile
@@ -35,11 +35,11 @@ clean:
 #
 
 $(TOOL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(TOOL) ]] || ([[ -e `which cabal` ]] && echo cabal > $(TOOL)) || true)
-	@([[ -s $(TOOL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
 
 $(REPL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(REPL) ]] || ([[ -e `which cabal` ]] && echo cabal repl > $(REPL)) || true)
-	@([[ -s $(REPL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_101/codelab/02_datatypes/Makefile
+++ b/haskell_101/codelab/02_datatypes/Makefile
@@ -35,11 +35,11 @@ clean:
 #
 
 $(TOOL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(TOOL) ]] || ([[ -e `which cabal` ]] && echo cabal > $(TOOL)) || true)
-	@([[ -s $(TOOL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
 
 $(REPL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(REPL) ]] || ([[ -e `which cabal` ]] && echo cabal repl > $(REPL)) || true)
-	@([[ -s $(REPL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_101/codelab/03_lists/Makefile
+++ b/haskell_101/codelab/03_lists/Makefile
@@ -35,11 +35,11 @@ clean:
 #
 
 $(TOOL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(TOOL) ]] || ([[ -e `which cabal` ]] && echo cabal > $(TOOL)) || true)
-	@([[ -s $(TOOL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
 
 $(REPL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(REPL) ]] || ([[ -e `which cabal` ]] && echo cabal repl > $(REPL)) || true)
-	@([[ -s $(REPL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_101/codelab/04_abstractions/Makefile
+++ b/haskell_101/codelab/04_abstractions/Makefile
@@ -35,11 +35,11 @@ clean:
 #
 
 $(TOOL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(TOOL) ]] || ([[ -e `which cabal` ]] && echo cabal > $(TOOL)) || true)
-	@([[ -s $(TOOL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
 
 $(REPL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(REPL) ]] || ([[ -e `which cabal` ]] && echo cabal repl > $(REPL)) || true)
-	@([[ -s $(REPL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_101/codelab/05_maybe/Makefile
+++ b/haskell_101/codelab/05_maybe/Makefile
@@ -35,11 +35,11 @@ clean:
 #
 
 $(TOOL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(TOOL) ]] || ([[ -e `which cabal` ]] && echo cabal > $(TOOL)) || true)
-	@([[ -s $(TOOL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
 
 $(REPL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(REPL) ]] || ([[ -e `which cabal` ]] && echo cabal repl > $(REPL)) || true)
-	@([[ -s $(REPL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_101/codelab/06_rps/Makefile
+++ b/haskell_101/codelab/06_rps/Makefile
@@ -35,11 +35,11 @@ clean:
 #
 
 $(TOOL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(TOOL) ]] || ([[ -e `which cabal` ]] && echo cabal > $(TOOL)) || true)
-	@([[ -s $(TOOL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
 
 $(REPL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(REPL) ]] || ([[ -e `which cabal` ]] && echo cabal repl > $(REPL)) || true)
-	@([[ -s $(REPL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_102/codelab/00_setup/Makefile
+++ b/haskell_102/codelab/00_setup/Makefile
@@ -35,11 +35,11 @@ clean:
 #
 
 $(TOOL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(TOOL) ]] || ([[ -e `which cabal` ]] && echo cabal > $(TOOL)) || true)
-	@([[ -s $(TOOL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
 
 $(REPL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(REPL) ]] || ([[ -e `which cabal` ]] && echo cabal repl > $(REPL)) || true)
-	@([[ -s $(REPL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_102/codelab/01_mastermind/Makefile
+++ b/haskell_102/codelab/01_mastermind/Makefile
@@ -31,6 +31,6 @@ clean:
 #
 
 $(TOOL):
-	@([[ -e `which stack` ]] && echo stack > $(TOOL) || true)
-	@([[ -s $(TOOL) ]] || ([[ -e `which cabal` ]] && echo cabal > $(TOOL)) || true)
-	@([[ -s $(TOOL) ]] || (cat setup.md && false))
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))


### PR DESCRIPTION
We were using `[[` construct but this is only valid under `/bin/bash`.
In systems where `/bin/sh` is just a symlink to `/bin/bash` we did not
catch the error. However, Reddit user u/chien-royal identified the error
while running the codelab on a different system (MacOS?).

Tested by running `/bin/dash` and then running `make` inside this shell.