### PR TITLE
Feature: a more efficient way to execute tests from docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 /haskell_*/slides/*.vrb
 /haskell_*/slides/auto/
 /haskell_*/slides/_minted-*/
+
+**/.stack-work/**
+**/*.lock
+**/.tool

--- a/haskell_101/codelab/Dockerfile
+++ b/haskell_101/codelab/Dockerfile
@@ -15,6 +15,10 @@ RUN --mount=type=bind,target=/docker-context \
 
 FROM haskell:8.10.7
 
+# Add vim to enable users to edit files locally while running within a container
+RUN apt-get update && \
+     apt-get install -y vim
+
 WORKDIR /google/trainings/haskell-101
 
 # Copy all cabal dependencies files only, fetched from docker-context

--- a/haskell_101/codelab/Dockerfile
+++ b/haskell_101/codelab/Dockerfile
@@ -1,11 +1,29 @@
+# syntax = docker/dockerfile:1.2
+
 # Using haskell:8 instead of latest due to deprecation warnings
 # on cabal
+FROM alpine AS dependencies
+
+# https://stackoverflow.com/questions/49939960/docker-copy-files-using-glob-pattern/66137816#66137816
+WORKDIR /google/trainings/haskell/cabal
+RUN --mount=type=bind,target=/docker-context \
+    cd /docker-context/; \
+    #find . -name "package.json" -mindepth 0 -maxdepth 4 -exec cp --parents "{}" /app/ \;
+    # https://unix.stackexchange.com/questions/15308/how-to-use-find-command-to-search-for-multiple-extensions/15309#15309
+    find . -type f \( -iname \*.cabal -o -iname \*.yaml\* \) -mindepth 0 -maxdepth 2 \
+         -exec cp --parents "{}" /google/trainings/haskell/cabal/ \;
+
 FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master
 
 WORKDIR /google/trainings/haskell
 
-# Copy all source files into container
-COPY . .
+# Copy all cabal dependencies files only, fetched from docker-context
+COPY --from=dependencies /google/trainings/haskell/cabal .
+
+# Copy also the Makefile with the dependency task
+COPY Makefile .
 
 RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}
 RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps
+
+COPY . .

--- a/haskell_101/codelab/Dockerfile
+++ b/haskell_101/codelab/Dockerfile
@@ -13,9 +13,9 @@ RUN --mount=type=bind,target=/docker-context \
     find . -type f \( -iname \*.cabal -o -iname \*.yaml\* \) -mindepth 0 -maxdepth 2 \
          -exec cp --parents "{}" /google/trainings/haskell/cabal/ \;
 
-FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master
+FROM haskell:8.10.7
 
-WORKDIR /google/trainings/haskell
+WORKDIR /google/trainings/haskell-101
 
 # Copy all cabal dependencies files only, fetched from docker-context
 COPY --from=dependencies /google/trainings/haskell/cabal .

--- a/haskell_101/codelab/Dockerfile
+++ b/haskell_101/codelab/Dockerfile
@@ -1,7 +1,0 @@
-# Using haskell:8 instead of latest due to deprecation warnings
-# on cabal
-FROM haskell:8
-WORKDIR .
-
-# Copy all source files into container
-COPY . .

--- a/haskell_101/codelab/Dockerfile
+++ b/haskell_101/codelab/Dockerfile
@@ -1,0 +1,11 @@
+# Using haskell:8 instead of latest due to deprecation warnings
+# on cabal
+FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master
+
+WORKDIR /google/trainings/haskell
+
+# Copy all source files into container
+COPY . .
+
+RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}
+RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps

--- a/haskell_101/codelab/Makefile
+++ b/haskell_101/codelab/Makefile
@@ -24,9 +24,6 @@ BUILD_GENERATED = dist dist-newstyle .stack-work stack.yaml.lock $(TOOL) $(REPL)
 repl: $(REPL)
 	@`cat $(REPL)` :$(TARGET)
 
-###
-### Just cache the dependencies when running the builds
-###
 deps: $(TOOL)
 	@`cat $(TOOL)` build --dependencies-only $(TARGET)
 

--- a/haskell_101/codelab/Makefile
+++ b/haskell_101/codelab/Makefile
@@ -1,0 +1,51 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.DEFAULT_GOAL := run
+.PHONY: repl run clean
+
+TARGET = codelab
+
+TOOL = .tool
+REPL = .repl_tool
+BUILD_GENERATED = dist dist-newstyle .stack-work stack.yaml.lock $(TOOL) $(REPL)
+
+repl: $(REPL)
+	@`cat $(REPL)` :$(TARGET)
+
+###
+### Just cache the dependencies when running the builds
+###
+deps: $(TOOL)
+	@`cat $(TOOL)` build --dependencies-only $(TARGET)
+
+run: $(TOOL)
+	@`cat $(TOOL)` run $(TARGET)
+
+clean:
+	@$(RM) -r $(BUILD_GENERATED)
+
+#
+# Private rules to check which toolchain is available
+#
+
+$(TOOL):
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
+
+$(REPL):
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_101/codelab/README.md
+++ b/haskell_101/codelab/README.md
@@ -8,8 +8,13 @@ To setup your machine please consult [the official haskell website](https://www.
 
 To run the tests just run `make` in each of the directories. The special `00_setup` directory is only used for testing the environment, but all others contain exercises to resolve.
 
+### From local haskell
+
+> **NOTE**: You must make sure your setup is working locally.
+
 For each of the exercises, replace `codelab` with your implementation. When complete, running `make` would result in an output similar to below:
-```
+
+```console
 add       1 2                             OK got: 3
 subtract  7 2                             OK got: 5
 double    3                               OK got: 6
@@ -21,45 +26,63 @@ gcd       12 4                            OK got: 4
 gcd       17 7                            OK got: 1
 ```
 
-If you are using the docker container, build and run the tests run with `docker-compose run <directory>` (without the trailing slash). For example, for `docker-compose run 01-functions`, you should see output similar to below:
-```
-Creating network "codelab_default" with the default driver
-Building 01_functions
-Step 1/3 : FROM haskell:8
-8: Pulling from library/haskell
-9b99af5931b3: Pull complete
-580a548160a1: Pull complete
-5d8e6deeb485: Pull complete
-70b0645032d3: Pull complete
-03b69c8eaa80: Pull complete
-Digest: sha256:d26c7a6853190096137361cfe65f5b7fc6e69ec4660ffb9583ec323e85b524e6
-Status: Downloaded newer image for haskell:8
- ---> 3baac1927856
-Step 2/3 : WORKDIR .
- ---> Running in 7b9c08684455
-Removing intermediate container 7b9c08684455
- ---> bd1bd24a236d
-Step 3/3 : COPY . .
- ---> 5012253dbb4f
+## Using a docker container
 
-Successfully built 5012253dbb4f
-Successfully tagged haskell101:latest
-Creating codelab_01_functions_run ... done
-make: Entering directory '/01_functions'
+If you are using the docker, build and run the tests run with `docker-compose up _EXERCISE_NAME_`. For example, for `docker-compose run 01-functions` runs the exercise `01-functions`, defined as a docker-compose service `01-functions` you should see output similar to below:
+
+> **NOTE**: the following output is longer the first time of the execution as the docker image is first created before docker-compose spawns a new docker container to execute the tests.
+
+```console
+$ docker-compose up 01_functions
+Starting codelab_01_functions_1 ... done
+Attaching to codelab_01_functions_1
+01_functions_1     | make: Entering directory '/google/trainings/haskell-101/01_functions'
+01_functions_1     | Completed 3 action(s).
+01_functions_1     | add       1 2                             OK got: 3
+01_functions_1     | subtract  7 2                             OK got: 5
+01_functions_1     | double    3                               OK got: 6
+01_functions_1     | multiply  3 11                            OK got: 33
+01_functions_1     | divide    9 2                             OK got: 4.5
+01_functions_1     | divide    8 4                             OK got: 2.0
+01_functions_1     | factorial 30                              OK got: 265252859812191058636308480000000
+01_functions_1     | gcd       12 4                            OK got: 4
+01_functions_1     | gcd       17 7                            OK got: 1
+01_functions_1     | make: Leaving directory '/google/trainings/haskell-101/01_functions'
+codelab_01_functions_1 exited with code 0
+```
+
+## From within a Docker Container
+
+* Running within a docker container means you have full access to haskell, stack, cabal, etc.
+
+> **NOTE**: this requires an update of docker-compose.yaml for the current version.
+
+```diff
+   03_lists:
+     <<: [ *generic-haskell-runtime ]
+-    #<<: [ *docker-cli-mode ]
+-    command: make -C 03_lists
++    <<: [ *docker-cli-mode ]
++    #command: make -C 03_lists
+```
+
+* Create a new container attached to the terminal
+
+> **NOTE**: The built docker image has `vim`, which will allows you to edit files 
+> from within the docker container and reflect when the container is terminated.
+
+```console
+$ docker-compose run 03_lists
+Creating codelab_03_lists_run ... done
+root@9bc17a3fe02a:/google/trainings/haskell-101# ghci --version
+The Glorious Glasgow Haskell Compilation System, version 8.10.7
+root@9bc17a3fe02a:/google/trainings/haskell-101# cd 03_lists/
+root@9bc17a3fe02a:/google/trainings/haskell-101/03_lists# vim src/
+Codelab.hs   Internal.hs  Main.hs      Solution.hs
+root@9bc17a3fe02a:/google/trainings/haskell-101/03_lists# vim src/Codelab.hs
+root@9bc17a3fe02a:/google/trainings/haskell-101/03_lists# stack run
+codelab> configure (exe)
+Configuring codelab-0.1.0.0...
 ...
-Completed 3 action(s).
-add       1 2                             OK got: 3
-subtract  7 2                             OK got: 5
-double    3                               OK got: 6
-multiply  3 11                            OK got: 33
-divide    9 2                             OK got: 4.5
-divide    8 4                             OK got: 2.0
-factorial 30                              OK got: 265252859812191058636308480000000
-gcd       12 4                            OK got: 4
-gcd       17 7                            OK got: 1
-make: Leaving directory '/01_functions'
+...
 ```
-
-Running the first time would result in downloading and compiling needed dependencies (omitted from the above screen output).
-
-When done, you can cleanup Docker services with `docker-compose down`.

--- a/haskell_101/codelab/docker-compose.yml
+++ b/haskell_101/codelab/docker-compose.yml
@@ -12,6 +12,11 @@ x-docker-cli-mode: &docker-cli-mode
   entrypoint: /bin/sh -c
   command: bash
 
+####
+#### you can execute the code as follows:
+#### 
+####      docker-compose up --build 0x_yyyyy 
+####
 services:
 
   00_setup:
@@ -25,6 +30,8 @@ services:
 
   02_datatypes:
     <<: [ *generic-haskell-runtime ]
+    # You can run in CLI mode with "docker-compose run 02_datatypes"
+    #<<: [ *docker-cli-mode ]
     command: make -C 02_datatypes
 
   03_lists:

--- a/haskell_101/codelab/docker-compose.yml
+++ b/haskell_101/codelab/docker-compose.yml
@@ -1,31 +1,44 @@
 version: '3'
+
+x-haskell-docker-setup: &generic-haskell-runtime
+  image: google/haskell-trainings
+  build: .
+
+# When setting the CLI mode, run the command docker-compose run SERVICE_NAME
+# https://stackoverflow.com/questions/36249744/interactive-shell-using-docker-compose/36265910#36265910 
+# Run with docker-compose run SERVICE
+# MUST ENABLE IT IN THE SERVICE BELOW
+x-docker-cli-mode: &docker-cli-mode
+  entrypoint: /bin/sh -c
+  command: bash
+
 services:
+
   00_setup:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
+    #<<: [ *docker-cli-mode ]
     command: make -C 00_setup
+
   01_functions:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 01_functions
+
   02_datatypes:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 02_datatypes
+
   03_lists:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 03_lists
+
   04_abstractions:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 04_abstractions
+
   05_maybe:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 05_maybe
+
   06_rps:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 06_rps
-    tty: true

--- a/haskell_101/codelab/docker-compose.yml
+++ b/haskell_101/codelab/docker-compose.yml
@@ -14,41 +14,62 @@ x-haskell-docker-setup: &generic-haskell-runtime
 x-docker-cli-mode: &docker-cli-mode
   entrypoint: /bin/sh -c
   command: bash
+  # When running within the container, make sure to mount the current dir. 
+  # This will allow persisting updates to any code of the dir from within the container.
+  volumes:
+    - .:/google/trainings/haskell-101
 
 ####
 #### you can execute the code as follows:
 #### 
 ####      docker-compose up --build 0x_yyyyy 
+#### 
+#### or execute a terminal by commenting out the "command" instruction and using the docker-cli-mode one. then:
+####
+####      docker-compose run 0x_yyyyy
+####
+####   NOTE: this execution is the same for any of the services defined
 ####
 services:
 
   00_setup:
     <<: [ *generic-haskell-runtime ]
+    # You can run in CLI mode with "docker-compose run 00_setup". Un-comment the following line and comment the "command" instruction below
     #<<: [ *docker-cli-mode ]
     command: make -C 00_setup
 
   01_functions:
     <<: [ *generic-haskell-runtime ]
+    # You can run in CLI mode with "docker-compose run 01_functions". Un-comment the following line and comment the "command" instruction below
+    #<<: [ *docker-cli-mode ]
     command: make -C 01_functions
 
   02_datatypes:
     <<: [ *generic-haskell-runtime ]
-    # You can run in CLI mode with "docker-compose run 02_datatypes"
+    # You can run in CLI mode with "docker-compose run 02_datatypes". Un-comment the following line and comment the "command" instruction below
     #<<: [ *docker-cli-mode ]
     command: make -C 02_datatypes
 
   03_lists:
     <<: [ *generic-haskell-runtime ]
+    # You can run in CLI mode with "docker-compose run 03_lists". Un-comment the following line and comment the "command" instruction below
+    #<<: [ *docker-cli-mode ]
     command: make -C 03_lists
 
   04_abstractions:
     <<: [ *generic-haskell-runtime ]
+    # You can run in CLI mode with "docker-compose run 04_abstractions". Un-comment the following line and comment the "command" instruction below
+    #<<: [ *docker-cli-mode ]
     command: make -C 04_abstractions
 
   05_maybe:
     <<: [ *generic-haskell-runtime ]
+    # You can run in CLI mode with "docker-compose run 05_maybe". Un-comment the following line and comment the "command" instruction below
+    #<<: [ *docker-cli-mode ]
     command: make -C 05_maybe
 
   06_rps:
     <<: [ *generic-haskell-runtime ]
+    # You can run in CLI mode with "docker-compose run 06_rps". Un-comment the following line and comment the "command" instruction below
+    #<<: [ *docker-cli-mode ]
     command: make -C 06_rps

--- a/haskell_101/codelab/docker-compose.yml
+++ b/haskell_101/codelab/docker-compose.yml
@@ -3,6 +3,9 @@ version: '3'
 x-haskell-docker-setup: &generic-haskell-runtime
   image: google/haskell-trainings
   build: .
+  # Preserve terminal colors when running containers
+  # https://github.com/docker/compose/issues/2231#issuecomment-425135985
+  tty: yes
 
 # When setting the CLI mode, run the command docker-compose run SERVICE_NAME
 # https://stackoverflow.com/questions/36249744/interactive-shell-using-docker-compose/36265910#36265910 


### PR DESCRIPTION
# 👍 Improvements

* Setting up a custom name of the `WORKDIR` to better document which exercise the user is working on
  `/google/trainings/haskell-101/00_setup`
* Properly implement a better Docker Cache for the haskell dependencies to avoid re-evaluating/downloading of the haskell dependencies when running `stack run`
  * Since the execution was placed in the container level, the dependencies were fetched at every execution
  * Added a `deps` Makefile task to be executed
* Documenting the way to execute a terminal from docker-compose
  * That way, users learning haskell can execute the commands internally to the image
* Allow users to solve the exercises from within a docker container
  * `vim` is now installed in the Docker image

> **NOTE**: This is a solution only for `haskell_101`. I can submit an additional PR for `haskell_202`, with more generalizations, if this PR gets to be merged.

Another important point is when debugging, users can provide better logs for debugging what's going, which training they are doing, etc...

```console
$ docker-compose up --build 03_lists
...
...
03_lists_1         | Installing executable solution in /google/trainings/haskell-101/03_lists/.stack-work/install/x86_64-linux/b75127df98e825dd26b7ce71e8ebbb670312dcae0b6d352496233a58a9f2a774/8.10.7/bin
03_lists_1         | null []                                   !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | null [8,0,6]                              codelab: src/Codelab.hs:40:1-23: Non-exhaustive patterns in function null
03_lists_1         |
03_lists_1         | make: *** [Makefile:28: run] Error 1
03_lists_1         | make: Leaving directory '/google/trainings/haskell-101/03_lists'
codelab_03_lists_1 exited with code 2
```

# 🐛 Bugfixes

## 🩹 Preserved Container coloring - `when in docker-compose`

* This is a known issue when running containers whose logs are colored
  * https://github.com/docker/compose/issues/2231#issuecomment-425135985
* As the underlying testing "framework" built in haskell explicitly added to get colored test results 
  * Without them, that may also be a problem for some (me included)

![Screen Shot 2022-01-11 at 9 21 55 AM](https://user-images.githubusercontent.com/131457/148991413-7a040443-f506-4767-94a0-5fcfe07a6040.png)

# ⚡ Performance improvements 🐳 

Created a single Makefile from a copy of setup, made it pull dependencies. That way, it's simpler for users to just run the docker container without having to re-run the entire process over and over again. Instead, taking advantage of the docker caching system by declaring a new layer in the `Dockerfile` to call the dependencies only.

## 💩 Inefficient runs

All the time running the current code the build pulls everything over and over again. That's just too much after a while. We have 2 options:

1. Create a base docker image for everything
2. Reuse the same `Dockerfile` for the same docker image
  * Updating the `Makefile` with a new task to get the dependencies
  * Run the dependencies for each of them

Since dependencies don't change often, the docker image cache works perfectly to just pull the same dependencies for codecolab's functions and the execution is left as is. This time, faster as it takes advantage of the dependencies already built into the docker image instead of the docker container (that is, the current version).

# 📝 Documented the way to run terminal from docker-compose

* Change the settings of docker-compose to include the cli-mode

```diff
$ git --no-pager diff docker-compose.yml
diff --git a/haskell_101/codelab/docker-compose.yml b/haskell_101/codelab/docker-compose.yml
index 4e6bb17..f87451f 100644
--- a/haskell_101/codelab/docker-compose.yml
+++ b/haskell_101/codelab/docker-compose.yml
@@ -53,8 +53,8 @@ services:
   03_lists:
     <<: [ *generic-haskell-runtime ]
     # You can run in CLI mode with "docker-compose run 03_lists". Un-comment the following line and comment the "command" instruction below
-    #<<: [ *docker-cli-mode ]
-    command: make -C 03_lists
+    <<: [ *docker-cli-mode ]
+    #command: make -C 03_lists

   04_abstractions:
```

* Then `run` a container instead of `up` a container 
  * You can edit a file using vim

```console
$ docker-compose run 03_lists
Creating codelab_03_lists_run ... done
root@f410c7d1db9e:/google/trainings/haskell-101#
root@f410c7d1db9e:/google/trainings/haskell-101# ghci
GHCi, version 8.10.7: https://www.haskell.org/ghc/  :? for help
Prelude>
Leaving GHCi.
root@f410c7d1db9e:/google/trainings/haskell-101/01_functions# vim src/Codelab.hs
root@f410c7d1db9e:/google/trainings/haskell-101/01_functions# exit
exit
root@f410c7d1db9e:/google/trainings/haskell-101# exit
exit
```

## 🔉 Docker Image: Build with Cached Dependencies

* Note that only the first project shows a full resolution of the dependencies at step `ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps`
  * The execution of the dependency resolution was added to a consolidated `Makefile` in the root of the dir.
* All the other executions are shown as `CACHED` 

```console
$ ls -d */ | awk -F/ '{ print $1 }' | xargs docker-compose build
Building 00_setup
[+] Building 1.2s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.4s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* ) -mindep  0.3s
 => [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                                  0.0s
 => [stage-1 4/7] COPY Makefile .                                                                                                                             0.0s
 => [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                                0.3s
 => [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                             7.5s
 => => # colour       > Preprocessing library for colour-2.3.6..
 => => # colour       > Building library for colour-2.3.6..
 => => # colour       > [ 1 of 14] Compiling Data.Colour.CIE.Chromaticity
 => => # colour       > [ 2 of 14] Compiling Data.Colour.CIE.Illuminant
 => => # colour       > [ 3 of 14] Compiling Data.Colour.Chan
 => => # colour       > [ 4 of 14] Compiling Data.Colour.Internal
 => [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                            23.4s
 => [stage-1 7/7] COPY . .                                                                                                                                    0.3s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:b1df76833ec4d2ab7b543f8df80416027e28777c855758361d02b557c8d654ad                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 01_functions
[+] Building 0.7s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:b1df76833ec4d2ab7b543f8df80416027e28777c855758361d02b557c8d654ad                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 02_datatypes
[+] Building 0.8s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:b1df76833ec4d2ab7b543f8df80416027e28777c855758361d02b557c8d654ad                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 03_lists
[+] Building 0.7s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:b1df76833ec4d2ab7b543f8df80416027e28777c855758361d02b557c8d654ad                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 04_abstractions
[+] Building 0.8s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:b1df76833ec4d2ab7b543f8df80416027e28777c855758361d02b557c8d654ad                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 05_maybe
[+] Building 0.9s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.1s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:b1df76833ec4d2ab7b543f8df80416027e28777c855758361d02b557c8d654ad                                                                  0.1s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 06_rps
[+] Building 0.7s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:b1df76833ec4d2ab7b543f8df80416027e28777c855758361d02b557c8d654ad                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings
```

# 👍 Faster solution: Docker Containers only compile and run binaries

* Since stack dependencies are resolved at docker image build-time, the process that executes `stack run` runs faster without pulling dependencies at every code change.
  * This is a reflection of the line `COPY . .` that is originally used in `Dockerfile`

```console
$ docker-compose up 00_setup
Starting codelab_00_setup_1 ... done
Attaching to codelab_00_setup_1
00_setup_1         | make: Entering directory '/google/trainings/haskell-101/00_setup'
00_setup_1         | ============================================
00_setup_1         |
00_setup_1         | Haskell toolchain is installed! All is good.
00_setup_1         |
00_setup_1         | ============================================
00_setup_1         | make: Leaving directory '/google/trainings/haskell-101/00_setup'
codelab_00_setup_1 exited with code 0
```

* All the dependencies were fetched during the docker image build
* We don't see the previous download of the dependencies anymore
  * Proved by Docker's cache system 
  * Logs show `CACHED` for every entry to the areas when it is executed
  * Forcing the rebuild will NOT pull the dependencies again

```console
$ docker-compose up --build 00_setup
Building 00_setup
[+] Building 1.4s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.5s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.4s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:46b636db7c83878a56f16bcd5162a38da8194e867a38b676c3ab480edf867144                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Starting codelab_00_setup_1 ... done
Attaching to codelab_00_setup_1
00_setup_1         | make: Entering directory '/google/trainings/haskell-101/00_setup'
00_setup_1         | ============================================
00_setup_1         |
00_setup_1         | Haskell toolchain is installed! All is good.
00_setup_1         |
00_setup_1         | ============================================
00_setup_1         | make: Leaving directory '/google/trainings/haskell-101/00_setup'
codelab_00_setup_1 exited with code 0
```

* The same applies to any other docker container created from docker-compose
  * Reusing the same docker image setup

```console
$ docker-compose up --build 03_lists
Building 03_lists
[+] Building 1.2s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.4s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:46b636db7c83878a56f16bcd5162a38da8194e867a38b676c3ab480edf867144                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Starting codelab_03_lists_1 ... done
Attaching to codelab_03_lists_1
03_lists_1         | make: Entering directory '/google/trainings/haskell-101/03_lists'
03_lists_1         | null []                                   !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | null [8,0,6]                              !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | head [8,0,6]                              !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | tail [8,0,6]                              !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | length []                                 !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | length [8,0,6]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    []                                 !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [True]                             !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [False]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [True,  True]                      !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [True,  False]                     !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [False, True]                      !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [False, False]                     !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [True, True, True]                 !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     []                                 !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [True]                             !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [False]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [True,  True]                      !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [True,  False]                     !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [False, True]                      !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [False, False]                     !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [False, False, True]               !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | [8,0] ++ [   ]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | [   ] ++ [6,4]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | [8,0] ++ [6,4]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | make: *** [Makefile:28: run] Error 1
03_lists_1         | make: Leaving directory '/google/trainings/haskell-101/03_lists'
codelab_03_lists_1 exited with code 2
```

# 🐛 🐳 Docker image `haskell:8` abs problem

* The full logs show that the base Haskell image has as a corrupted `abs` function...
  * This doesn't happen in manual haskell installation, which is what I have.

```console
$ docker-compose up --build 01_functions
Building 01_functions
[+] Building 1.2s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.4s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
...
...                                                                                                                       0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:46b636db7c83878a56f16bcd5162a38da8194e867a38b676c3ab480edf867144                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Recreating codelab_01_functions_1 ... done
Attaching to codelab_01_functions_1
01_functions_1     | make: Entering directory '/google/trainings/haskell-101/01_functions'
01_functions_1     | codelab> configure (exe)
01_functions_1     | Configuring codelab-0.1.0.0...
01_functions_1     | InvalidAbsFile "/.ghcup/ghc/8.10.7/lib/ghc-8.10.7/lib/../lib/x86_64-linux-ghc-8.10.7/rts-1.0.1/include/ghcversion.h"
01_functions_1     | make: *** [Makefile:28: run] Error 1
01_functions_1     | make: Leaving directory '/google/trainings/haskell-101/01_functions'
codelab_01_functions_1 exited with code 2

$ docker-compose up --build 02_datatypes
Building 02_datatypes
[+] Building 3.1s (20/20) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 1.28kB                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  1.0s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                              0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.6s
 => [auth] library/haskell:pull token for registry-1.docker.io
...
...
Recreating codelab_02_datatypes_1 ... done
Attaching to codelab_02_datatypes_1
02_datatypes_1     | make: Entering directory '/google/trainings/haskell-101/02_datatypes'
02_datatypes_1     | codelab> configure (exe)
02_datatypes_1     | Configuring codelab-0.1.0.0...
02_datatypes_1     | InvalidAbsFile "/.ghcup/ghc/8.10.7/lib/ghc-8.10.7/lib/../lib/x86_64-linux-ghc-8.10.7/rts-1.0.1/include/ghcversion.h"
02_datatypes_1     | make: *** [Makefile:28: run] Error 1
02_datatypes_1     | make: Leaving directory '/google/trainings/haskell-101/02_datatypes'
codelab_02_datatypes_1 exited with code 2
```

## 👍 🔉 Logs with personal Haskell image working

> I built haskell manually and it's working registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master

```console
$ docker-compose up --build 01_functions
Building 01_functions
[+] Building 0.8s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                             0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [stage-1 1/7] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                       0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:c8aeca37c1f5d263cea5acfce7a94f9dad21d18459475d5ff7f44daac1e9d420                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Starting codelab_01_functions_1 ... done
Attaching to codelab_01_functions_1
01_functions_1     | make: Entering directory '/google/trainings/haskell-101/01_functions'
01_functions_1     | add       1 2                             !! error: SOMETHING IS NOT IMPLEMENTED!
01_functions_1     | subtract  7 2                             !! error: SOMETHING IS NOT IMPLEMENTED!
01_functions_1     | double    3                               !! error: SOMETHING IS NOT IMPLEMENTED!
01_functions_1     | multiply  3 11                            !! error: SOMETHING IS NOT IMPLEMENTED!
01_functions_1     | divide    9 2                             !! error: SOMETHING IS NOT IMPLEMENTED!
01_functions_1     | divide    8 4                             !! error: SOMETHING IS NOT IMPLEMENTED!
01_functions_1     | factorial 30                              !! error: SOMETHING IS NOT IMPLEMENTED!
01_functions_1     | gcd       12 4                            !! error: SOMETHING IS NOT IMPLEMENTED!
01_functions_1     | gcd       17 7                            !! error: SOMETHING IS NOT IMPLEMENTED!
01_functions_1     | make: *** [Makefile:28: run] Error 1
01_functions_1     | make: Leaving directory '/google/trainings/haskell-101/01_functions'
codelab_01_functions_1 exited with code 2

☁️  aws-cli@2.2.32 🔖 aws-iam-authenticator@0.5.3
☸️  kubectl@1.22.4 📛 kustomize@v4.3.0 🎡 helm@3.7.0 👽 argocd@2.2.0 ✈️  glooctl@1.9.0 🐳 docker@20.10.11 🐙 docker-compose@1.29.2
👤 AWS_PS1_PROFILE 🗂️   🌎 sa-east-1
🏗  1.21.2-eks-0389ca3 🔐 arn:aws:eks:sa-east-1:806101772216:cluster/eks-ppd-prd-super-cash 🍱 default
~/dev/github.com/marcellodesales/haskell-trainings/haskell_101/codelab on  feature/more-efficient-docker-compose-execution! 📅 01-11-2022 ⌚10:27:44
$ docker-compose up --build 02_datatypes
Building 02_datatypes
[+] Building 1.0s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.5s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                             0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [stage-1 1/7] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                       0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell-101                                                                                                0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:c8aeca37c1f5d263cea5acfce7a94f9dad21d18459475d5ff7f44daac1e9d420                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Starting codelab_02_datatypes_1 ... done
Attaching to codelab_02_datatypes_1
02_datatypes_1     | make: Entering directory '/google/trainings/haskell-101/02_datatypes'
02_datatypes_1     | hours (Minutes 271)                       !! error: SOMETHING IS NOT IMPLEMENTED!
02_datatypes_1     | hours (Minutes 15)                        !! error: SOMETHING IS NOT IMPLEMENTED!
02_datatypes_1     | timeDistance (Minutes 15) (Minutes 25)    !! error: SOMETHING IS NOT IMPLEMENTED!
02_datatypes_1     | timeDistance (Minutes 99) (Minutes 47)    !! error: SOMETHING IS NOT IMPLEMENTED!
02_datatypes_1     | pointDistance (1, 1) (1, 3)               !! error: SOMETHING IS NOT IMPLEMENTED!
02_datatypes_1     | pointDistance (3, 4) (0, 0)               !! error: SOMETHING IS NOT IMPLEMENTED!
02_datatypes_1     | make: *** [Makefile:28: run] Error 1
02_datatypes_1     | make: Leaving directory '/google/trainings/haskell-101/02_datatypes'
codelab_02_datatypes_1 exited with code 2
```

## 🐛 🔊 Full logs of running all in parallel with `haskell:8`

> **NOTE**: Test 06_rps_1  is blocking the container waiting for the user's input... While this might be part of the requirement, executing the tests in a CI environment would not work...

```console
$ ls -d */ | awk -F/ '{ print $1 }' | xargs docker-compose up --build
Removing codelab_06_rps_1
Building 00_setup
[+] Building 1.9s (20/20) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  1.0s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                              0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.6s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [auth] library/haskell:pull token for registry-1.docker.io                                                                                                0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell                                                                                                    0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:ab52b886c38b3ae9a4f2fe1631d272bf11388d5b55c1d5b78b4b584e86085e6f                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 01_functions
[+] Building 0.8s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell                                                                                                    0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.1s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:ab52b886c38b3ae9a4f2fe1631d272bf11388d5b55c1d5b78b4b584e86085e6f                                                                  0.1s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 02_datatypes
[+] Building 0.7s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell                                                                                                    0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:ab52b886c38b3ae9a4f2fe1631d272bf11388d5b55c1d5b78b4b584e86085e6f                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 03_lists
[+] Building 0.7s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell                                                                                                    0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:ab52b886c38b3ae9a4f2fe1631d272bf11388d5b55c1d5b78b4b584e86085e6f                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 04_abstractions
[+] Building 0.8s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell                                                                                                    0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:ab52b886c38b3ae9a4f2fe1631d272bf11388d5b55c1d5b78b4b584e86085e6f                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 05_maybe
[+] Building 0.7s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell                                                                                                    0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:ab52b886c38b3ae9a4f2fe1631d272bf11388d5b55c1d5b78b4b584e86085e6f                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Building 06_rps
[+] Building 0.7s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                             0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                              0.0s
 => [internal] load metadata for docker.io/library/haskell:8.10.7                                                                                             0.2s
 => [internal] load build context                                                                                                                             0.0s
 => => transferring context: 19.81kB                                                                                                                          0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                          0.0s
 => [stage-1 1/7] FROM docker.io/library/haskell:8.10.7@sha256:6b4948a36e40b66a9cd6bfc279df43958d1aebc67a3909ba0c521d1d1395d26f                               0.0s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell                                                                                                    0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                         0.0s
 => CACHED [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* )   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                           0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                      0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                         0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                      0.0s
 => CACHED [stage-1 7/7] COPY . .                                                                                                                             0.0s
 => exporting to image                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                       0.0s
 => => writing image sha256:ab52b886c38b3ae9a4f2fe1631d272bf11388d5b55c1d5b78b4b584e86085e6f                                                                  0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                           0.0s
Starting codelab_01_functions_1          ... done
Recreating 7b362282ef91_codelab_06_rps_1 ... done
Starting codelab_02_datatypes_1          ... done
Recreating codelab_05_maybe_1            ... done
Recreating codelab_00_setup_1            ... done
Recreating codelab_04_abstractions_1     ... done
Starting codelab_03_lists_1              ... done
Attaching to codelab_01_functions_1, codelab_03_lists_1, codelab_02_datatypes_1, codelab_06_rps_1, codelab_00_setup_1, codelab_05_maybe_1, codelab_04_abstractions_1
01_functions_1     | make: Entering directory '/google/trainings/haskell/01_functions'
01_functions_1     | InvalidAbsFile "/.ghcup/ghc/8.10.7/lib/ghc-8.10.7/lib/../lib/x86_64-linux-ghc-8.10.7/rts-1.0.1/include/ghcversion.h"
01_functions_1     | make: *** [Makefile:28: run] Error 1
01_functions_1     | make: Leaving directory '/google/trainings/haskell/01_functions'
00_setup_1         | make: Entering directory '/google/trainings/haskell/00_setup'
02_datatypes_1     | make: Entering directory '/google/trainings/haskell/02_datatypes'
04_abstractions_1  | make: Entering directory '/google/trainings/haskell/04_abstractions'
03_lists_1         | make: Entering directory '/google/trainings/haskell/03_lists'
05_maybe_1         | make: Entering directory '/google/trainings/haskell/05_maybe'
06_rps_1           | make: Entering directory '/google/trainings/haskell/06_rps'
codelab_01_functions_1 exited with code 2
03_lists_1         | null []                                   !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | null [8,0,6]                              !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | head [8,0,6]                              !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | tail [8,0,6]                              !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | length []                                 !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | length [8,0,6]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    []                                 !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [True]                             !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [False]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [True,  True]                      !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [True,  False]                     !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [False, True]                      !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [False, False]                     !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | and    [True, True, True]                 !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     []                                 !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [True]                             !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [False]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [True,  True]                      !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [True,  False]                     !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [False, True]                      !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [False, False]                     !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | or     [False, False, True]               !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | [8,0] ++ [   ]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | [   ] ++ [6,4]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | [8,0] ++ [6,4]                            !! error: SOMETHING IS NOT IMPLEMENTED!
03_lists_1         | make: *** [Makefile:28: run] Error 1
03_lists_1         | make: Leaving directory '/google/trainings/haskell/03_lists'
codelab_03_lists_1 exited with code 2
02_datatypes_1     | InvalidAbsFile "/.ghcup/ghc/8.10.7/lib/ghc-8.10.7/lib/../lib/x86_64-linux-ghc-8.10.7/rts-1.0.1/include/ghcversion.h"
02_datatypes_1     | make: *** [Makefile:28: run] Error 1
02_datatypes_1     | make: Leaving directory '/google/trainings/haskell/02_datatypes'
06_rps_1           | Building all executables for `codelab' once. After a successful build of all of them, only specified executables will be rebuilt.
06_rps_1           | codelab> configure (exe)
00_setup_1         | codelab> configure (exe)
codelab_02_datatypes_1 exited with code 2
05_maybe_1         | Building all executables for `codelab' once. After a successful build of all of them, only specified executables will be rebuilt.
05_maybe_1         | codelab> configure (exe)
04_abstractions_1  | Building all executables for `codelab' once. After a successful build of all of them, only specified executables will be rebuilt.
04_abstractions_1  | codelab> configure (exe)
06_rps_1           | Configuring codelab-0.1.0.0...
00_setup_1         | Configuring codelab-0.1.0.0...
05_maybe_1         | Configuring codelab-0.1.0.0...
04_abstractions_1  | Configuring codelab-0.1.0.0...
06_rps_1           | codelab> build (exe)
00_setup_1         | codelab> build (exe)
06_rps_1           | Preprocessing executable 'codelab' for codelab-0.1.0.0..
06_rps_1           | Building executable 'codelab' for codelab-0.1.0.0..
05_maybe_1         | codelab> build (exe)
05_maybe_1         | Preprocessing executable 'codelab' for codelab-0.1.0.0..
05_maybe_1         | Building executable 'codelab' for codelab-0.1.0.0..
00_setup_1         | Preprocessing executable 'codelab' for codelab-0.1.0.0..
00_setup_1         | Building executable 'codelab' for codelab-0.1.0.0..
04_abstractions_1  | codelab> build (exe)
06_rps_1           | [1 of 3] Compiling Internal
04_abstractions_1  | Preprocessing executable 'codelab' for codelab-0.1.0.0..
04_abstractions_1  | Building executable 'codelab' for codelab-0.1.0.0..
05_maybe_1         | [1 of 3] Compiling Internal
00_setup_1         | [1 of 1] Compiling Main [Prelude changed]
04_abstractions_1  | [1 of 3] Compiling Internal
00_setup_1         | Linking .stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/codelab/codelab ...
06_rps_1           | [2 of 3] Compiling Codelab
05_maybe_1         | [2 of 3] Compiling Codelab
05_maybe_1         | [3 of 3] Compiling Main
04_abstractions_1  | [2 of 3] Compiling Codelab
04_abstractions_1  | [3 of 3] Compiling Main
06_rps_1           | [3 of 3] Compiling Main
05_maybe_1         | Linking .stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/codelab/codelab ...
04_abstractions_1  | Linking .stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/codelab/codelab ...
00_setup_1         | codelab> copy/register
00_setup_1         | Installing executable codelab in /google/trainings/haskell/00_setup/.stack-work/install/x86_64-linux/918a7a91b3f61592c6866bfa024bf1b0d9f5e73cebb23fd806ab595092ce6902/8.10.7/bin
00_setup_1         | Installing executable solution in /google/trainings/haskell/00_setup/.stack-work/install/x86_64-linux/918a7a91b3f61592c6866bfa024bf1b0d9f5e73cebb23fd806ab595092ce6902/8.10.7/bin
00_setup_1         | ============================================
00_setup_1         |
00_setup_1         | Haskell toolchain is installed! All is good.
00_setup_1         |
00_setup_1         | ============================================
00_setup_1         | make: Leaving directory '/google/trainings/haskell/00_setup'
06_rps_1           | Linking .stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/codelab/codelab ...
codelab_00_setup_1 exited with code 0
05_maybe_1         | Preprocessing executable 'solution' for codelab-0.1.0.0..
05_maybe_1         | Building executable 'solution' for codelab-0.1.0.0..
04_abstractions_1  | Preprocessing executable 'solution' for codelab-0.1.0.0..
04_abstractions_1  | Building executable 'solution' for codelab-0.1.0.0..
05_maybe_1         | [1 of 3] Compiling Internal
04_abstractions_1  | [1 of 3] Compiling Internal
06_rps_1           | Preprocessing executable 'solution' for codelab-0.1.0.0..
06_rps_1           | Building executable 'solution' for codelab-0.1.0.0..
06_rps_1           | [1 of 3] Compiling Internal
05_maybe_1         | [2 of 3] Compiling Solution
04_abstractions_1  | [2 of 3] Compiling Solution
05_maybe_1         | [3 of 3] Compiling Main
04_abstractions_1  | [3 of 3] Compiling Main
06_rps_1           | [2 of 3] Compiling Solution
05_maybe_1         | Linking .stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/solution/solution ...
04_abstractions_1  | Linking .stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/solution/solution ...
06_rps_1           | [3 of 3] Compiling Main
04_abstractions_1  | codelab> copy/register
05_maybe_1         | codelab> copy/register
04_abstractions_1  | Installing executable codelab in /google/trainings/haskell/04_abstractions/.stack-work/install/x86_64-linux/918a7a91b3f61592c6866bfa024bf1b0d9f5e73cebb23fd806ab595092ce6902/8.10.7/bin
04_abstractions_1  | Installing executable solution in /google/trainings/haskell/04_abstractions/.stack-work/install/x86_64-linux/918a7a91b3f61592c6866bfa024bf1b0d9f5e73cebb23fd806ab595092ce6902/8.10.7/bin
05_maybe_1         | Installing executable codelab in /google/trainings/haskell/05_maybe/.stack-work/install/x86_64-linux/918a7a91b3f61592c6866bfa024bf1b0d9f5e73cebb23fd806ab595092ce6902/8.10.7/bin
05_maybe_1         | Installing executable solution in /google/trainings/haskell/05_maybe/.stack-work/install/x86_64-linux/918a7a91b3f61592c6866bfa024bf1b0d9f5e73cebb23fd806ab595092ce6902/8.10.7/bin
04_abstractions_1  | map    (+1)   []                          !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | map    (+1)   [8,0,6,4]                   !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | filter (>5)   []                          !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | filter (>5)   [8,0,6,4]                   !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | foldl  (-)  1   [10]                      !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | foldl  (-)  0   [1,2,3,4]                 !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | foldl  (++) "_" ["A", "B", "C"]           !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | foldr  (-)  1   [10]                      !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | foldr  (-)  0   [1,2,3,4]                 !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | foldr  (++) "_" ["A", "B", "C"]           !! error: SOMETHING IS NOT IMPLEMENTED!
04_abstractions_1  | make: *** [Makefile:28: run] Error 1
04_abstractions_1  | make: Leaving directory '/google/trainings/haskell/04_abstractions'
05_maybe_1         | safeHead  []                              !! error: SOMETHING IS NOT IMPLEMENTED!
05_maybe_1         | safeHead  [8,0,6]                         !! error: SOMETHING IS NOT IMPLEMENTED!
05_maybe_1         | isNothing (Just 42)                       !! error: SOMETHING IS NOT IMPLEMENTED!
05_maybe_1         | isNothing Nothing                         !! error: SOMETHING IS NOT IMPLEMENTED!
05_maybe_1         | fromMaybe 0 (Just 40)                     !! error: SOMETHING IS NOT IMPLEMENTED!
05_maybe_1         | fromMaybe 0 Nothing                       !! error: SOMETHING IS NOT IMPLEMENTED!
05_maybe_1         | maybe 0 (+2) (Just 40)                    !! error: SOMETHING IS NOT IMPLEMENTED!
05_maybe_1         | maybe 0 (+2) Nothing                      !! error: SOMETHING IS NOT IMPLEMENTED!
05_maybe_1         | make: *** [Makefile:28: run] Error 1
05_maybe_1         | make: Leaving directory '/google/trainings/haskell/05_maybe'
06_rps_1           | Linking .stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/solution/solution ...
codelab_04_abstractions_1 exited with code 2
codelab_05_maybe_1 exited with code 2
06_rps_1           | codelab> copy/register
06_rps_1           | Installing executable codelab in /google/trainings/haskell/06_rps/.stack-work/install/x86_64-linux/918a7a91b3f61592c6866bfa024bf1b0d9f5e73cebb23fd806ab595092ce6902/8.10.7/bin
06_rps_1           | Installing executable solution in /google/trainings/haskell/06_rps/.stack-work/install/x86_64-linux/918a7a91b3f61592c6866bfa024bf1b0d9f5e73cebb23fd806ab595092ce6902/8.10.7/bin
06_rps_1           | Welcome to Rock-Paper-Scissors!
06_rps_1           | -------------------------------
06_rps_1           | Each move is one of [Rock,Paper,Scissors]
```